### PR TITLE
Fix AudioBookmark.time and DeleteBookmark.time types to Double

### DIFF
--- a/Sources/AudiobookshelfAPI/Interfaces/Me/DeleteBookmark.swift
+++ b/Sources/AudiobookshelfAPI/Interfaces/Me/DeleteBookmark.swift
@@ -34,7 +34,7 @@ public struct DeleteBookmark: Interface {
         ///   - time: The time (in seconds) of the bookmark to delete.
         public init(
             libraryItemId: String,
-            time: Int
+            time: Double
         ) {
             self.path = "/api/me/item/\(libraryItemId)/bookmark/\(time)"
         }

--- a/Sources/AudiobookshelfAPI/Models/AudioBookmark.swift
+++ b/Sources/AudiobookshelfAPI/Models/AudioBookmark.swift
@@ -16,7 +16,7 @@ public struct AudioBookmark {
     public let title: String
 
     /// The time (in seconds) the bookmark is at in the book.
-    public let time: Int
+    public let time: Double
 
     /// The time (in ms since POSIX epoch) when the bookmark was created.
     public let createdAt: Int


### PR DESCRIPTION
The server stores and returns bookmark timestamps as fractional seconds (e.g. 123.45). AudioBookmark.time was decoded as Int, silently truncating sub-second precision. DeleteBookmark's path parameter was also Int, causing silent no-op deletes for any bookmark created at a fractional timestamp since the server's equality check would fail to match.