### PR TITLE
Fix GetLibraryCollections.Response field names

### DIFF
--- a/Sources/AudiobookshelfAPI/Interfaces/Libraries/GetLibraryCollections.swift
+++ b/Sources/AudiobookshelfAPI/Interfaces/Libraries/GetLibraryCollections.swift
@@ -83,28 +83,28 @@ public struct GetLibraryCollections: Interface {
         public let results: [Collection]
 
         /// The total number of results.
-        public let rtotal: Int
+        public let total: Int
 
         /// The limit set in the request.
-        public let rlimit: Int
+        public let limit: Int
 
         /// The page set in request.
-        public let rpage: Int
+        public let page: Int
 
         /// The sort set in the request. Will not exist if no sort was set.
-        public let rsortBy: String?
+        public let sortBy: String?
 
         /// Whether to reverse the sort order.
-        public let rsortDesc: Bool
+        public let sortDesc: Bool
 
         /// The filter set in the request, URL decoded. Will not exist if no filter was set.
-        public let rfilterBy: String?
+        public let filterBy: String?
 
         /// Whether minified was set in the request.
-        public let rminified: Bool
+        public let minified: Bool
 
         /// The requested include.
-        public let rinclude: String
+        public let include: String
 
     }
 


### PR DESCRIPTION
## Summary

- `GetLibraryCollections.Response` had an erroneous `r` prefix on all pagination/metadata fields (`rtotal`, `rlimit`, `rpage`, `rsortBy`, `rsortDesc`, `rfilterBy`, `rminified`, `rinclude`)
- These didn't match the actual JSON keys the server returns, causing decoding to fail on every call to this endpoint
- Verified the correct field names against `LibraryController.js` → `getCollectionsForLibrary` in the audiobookshelf server

The other three related interfaces (`GetLibraryUserPlaylists`, `GetAllCollections`, `GetUserPlaylists`) were audited and are correct.

## Test plan

- [ ] Call `GET /api/libraries/:id/collections` — response should now decode without error
- [ ] Verify `results`, `total`, `limit`, `page` are populated
- [ ] Verify optional fields (`sortBy`, `filterBy`) are nil when not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)